### PR TITLE
Fixed TwoLevelCache bug

### DIFF
--- a/app/code/core/Mage/Core/Model/Cache.php
+++ b/app/code/core/Mage/Core/Model/Cache.php
@@ -44,7 +44,7 @@ class Mage_Core_Model_Cache
     /**
      * Cache frontend API
      *
-     * @var Zend_Cache_Core
+     * @var Varien_Cache_Core
      */
     protected $_frontend    = null;
 
@@ -122,6 +122,9 @@ class Mage_Core_Model_Cache
         $this->_frontend = Zend_Cache::factory('Varien_Cache_Core', $backend['type'], $frontend, $backend['options'],
             true, true, true
         );
+        if (isset($options['default_priority'])) {
+            $this->_frontend->setDefaultPriority($options['default_priority']);
+        }
 
         if (isset($options['request_processors'])) {
             $this->_requestProcessors = $options['request_processors'];

--- a/lib/Varien/Cache/Core.php
+++ b/lib/Varien/Cache/Core.php
@@ -27,6 +27,22 @@
 class Varien_Cache_Core extends Zend_Cache_Core
 {
     /**
+     * @var int default cache priority
+     */
+    protected $defaultPriority = 8;
+
+    /**
+     * Set default priority
+     *
+     * @param int $defaultPriority
+     * @return Varien_Cache_Core
+     */
+    public function setDefaultPriority($defaultPriority) {
+        $this->defaultPriority = $defaultPriority;
+        return $this;
+    }
+
+    /**
      * Make and return a cache id
      *
      * Checks 'cache_id_prefix' and returns new id with prefix or simply the id if null
@@ -70,8 +86,11 @@ class Varien_Cache_Core extends Zend_Cache_Core
      * @throws Zend_Cache_Exception
      * @return boolean True if no problem
      */
-    public function save($data, $id = null, $tags = array(), $specificLifetime = false, $priority = 8)
+    public function save($data, $id = null, $tags = array(), $specificLifetime = false, $priority = null)
     {
+        if (is_null($priority)) {
+            $priority = $this->defaultPriority;
+        }
         $tags = $this->_tags($tags);
         return parent::save($data, $id, $tags, $specificLifetime, $priority);
     }

--- a/lib/Zend/Cache/Backend/TwoLevels.php
+++ b/lib/Zend/Cache/Backend/TwoLevels.php
@@ -443,7 +443,7 @@ class Zend_Cache_Backend_TwoLevels extends Zend_Cache_Backend implements Zend_Ca
             'automatic_cleaning' => $slowBackendCapabilities['automatic_cleaning'],
             'tags' => $slowBackendCapabilities['tags'],
             'expired_read' => $slowBackendCapabilities['expired_read'],
-            'priority' => $slowBackendCapabilities['priority'],
+            'priority' => true,
             'infinite_lifetime' => $slowBackendCapabilities['infinite_lifetime'],
             'get_list' => $slowBackendCapabilities['get_list']
         );


### PR DESCRIPTION
- See related blogpost by @fbrnc => http://www.fabrizio-branca.de/magento-zend-frameworks-twolevels-cache-backend-mess.html
- I just applied the patch and replaced tabs with spaces and removed some unnecessary whitespace.
- Github issue: #246 